### PR TITLE
Add ability to split content in include files.

### DIFF
--- a/source/includes/_errors.md
+++ b/source/includes/_errors.md
@@ -1,0 +1,18 @@
+# Errors
+
+The Kittn API uses the following error codes:
+
+
+Error Code | Meaning
+---------- | -------
+400 | Bad Request -- Your request sucks
+401 | Unauthorized -- Your API key is wrong
+403 | Forbidden -- The kitten requested is hidden for administrators only
+404 | Not Found -- The specified kitten could not be found
+405 | Method Not Allowed -- You tried to access a kitten with an invalid method
+406 | Not Acceptable -- You requested a format that isn't json
+410 | Gone -- The kitten requested has been removed from our servers
+418 | I'm a teapot
+429 | Too Many Requests -- You're requesting too many kittens! Slown down!
+500 | Internal Server Error -- We had a problem with our server. Try again later.
+503 | Service Unavailable -- We're temporarially offline for maintanance. Please try again later.

--- a/source/index.md
+++ b/source/index.md
@@ -7,8 +7,12 @@ language_tabs:
   - python
 
 toc_footers:
- - <a href='#'>Sign Up for a Developer Key</a>
- - <a href='http://github.com/tripit/slate'>Documentation Powered by Slate</a>
+  - <a href='#'>Sign Up for a Developer Key</a>
+  - <a href='http://github.com/tripit/slate'>Documentation Powered by Slate</a>
+
+includes:
+  - errors
+
 ---
 
 # Introduction
@@ -161,21 +165,3 @@ Parameter | Description
 --------- | -----------
 ID | The ID of the cat to retrieve
 
-# Errors
-
-The Kittn API uses the following error codes:
-
-
-Error Code | Meaning
----------- | -------
-400 | Bad Request -- Your request sucks
-401 | Unauthorized -- Your API key is wrong
-403 | Forbidden -- The kitten requested is hidden for administrators only
-404 | Not Found -- The specified kitten could not be found
-405 | Method Not Allowed -- You tried to access a kitten with an invalid method
-406 | Not Acceptable -- You requested a format that isn't json
-410 | Gone -- The kitten requested has been removed from our servers
-418 | I'm a teapot
-429 | Too Many Requests -- You're requesting too many kittens! Slown down!
-500 | Internal Server Error -- We had a problem with our server. Try again later.
-503 | Service Unavailable -- We're temporarially offline for maintanance. Please try again later.

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -83,6 +83,11 @@ under the License.
     <div class="page-wrapper">
       <div class="content">
         <%= yield %>
+        <% if current_page.data.includes %>
+          <% current_page.data.includes.each do |include| %>
+            <%= partial "includes/#{include}" %>
+          <% end %>
+        <% end %>
       </div>
       <div class="dark-box">
         <div id="lang-selector">


### PR DESCRIPTION
With this pull request, users can now include extra markdown files in the rendered result.

The list of files to be included should be in the collection names _includes_ at the top of the index.md file, in the order that they should be included. The content from the included files will be added after the content from the index.md file.

The included files should be created in the source/includes folder and be named with a leading underscore (e.g. source/includes/_errors.md).
