### PR TITLE
Prevent flash on first load

### DIFF
--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -52,6 +52,7 @@ under the License.
       <% end %>
     </div>
     <div class="page-wrapper">
+      <div class="dark-box"></div>
       <div class="search-info"></div>
       <div class="content">
         <%= yield %>


### PR DESCRIPTION
The dev branch has an even worse flash on load. I wonder if there's a better fix. In theory the site is static so possibly the menus could be generated in advance to eliminate the strange layout issues on load.
