### PR TITLE
Show an example of using a Hash for a language tab

### DIFF
--- a/source/index.md
+++ b/source/index.md
@@ -3,7 +3,7 @@ title: API Reference
 
 language_tabs:
   - shell
-  - ruby
+  - {"ruby":"ruby"}
   - python
 
 toc_footers:


### PR DESCRIPTION
An as-of-yet undocumented feature is that you can use a Hash/Dictionary for the language specifications - you're not limited to have tab names that correlate 1:1 with the syntax highlighter's supported languages. A great example could be for iOS code: {"objective_c":"iOS"}.

This should also be mentioned in the community wiki.
