### PR TITLE
Changing the code font-family to prefer Menlo/Consolas over Monaco

### DIFF
--- a/source/stylesheets/variables.scss
+++ b/source/stylesheets/variables.scss
@@ -75,7 +75,7 @@ $h1-margin-bottom: 21px; // padding under the largest header tags
 }
 
 %code-font {
-  font-family: Monaco, "Courier New", monospace;
+  font-family: Consolas, Menlo, Monaco, Lucida Console, Liberation Mono, DejaVu Sans Mono, Bitstream Vera Sans Mono, Courier New, monospace, serif;
   font-size: 12px;
 }
 


### PR DESCRIPTION
I've been running into a few issues with Monaco. Notably, that it doesn't have a true bold version. In highlighting objective-c code, for example, rouge uses bold to highlight some parts of the text. With Monaco not only does this cause a blurry type, but it also breaks monospace. 

This change alters the font-family order to mirror what StackOverflow uses. Consolas, which is well supported by Windows, Menlo, which is the default is Xcode and supports bold, and includes the current Monaco as the third option and then a bunch of others as fallbacks.
