### PR TITLE
Remove orchestrate.io from examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,6 @@ Examples of Slate in the Wild
 
 * [Travis-CI's API docs](http://docs.travis-ci.com/api/)
 * [Mozilla's localForage docs](http://mozilla.github.io/localForage/)
-* [Orchestrate.io API docs](https://docs.orchestrate.io/)
 * [ChaiOne Gameplan API docs](http://chaione.github.io/gameplanb2b/#introduction)
 * [Drcaban's Build a Quine tutorial](http://drcabana.github.io/build-a-quine/#introduction)
 * [PricePlow API docs](https://www.priceplow.com/api/documentation)


### PR DESCRIPTION
It seems to no longer use Slate
