### PR TITLE
Update eventmachine@1.0.4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -30,7 +30,7 @@ GEM
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0.6.0)
     erubis (2.7.0)
-    eventmachine (1.0.3)
+    eventmachine (1.0.4)
     execjs (2.2.2)
     ffi (1.9.6)
     haml (4.0.5)


### PR DESCRIPTION
Fixes compatibility with Ruby 2.2.

See https://github.com/eventmachine/eventmachine/issues/495.