### PR TITLE
Slate server configuration.

### DIFF
--- a/slate_apache_virtualhost.conf
+++ b/slate_apache_virtualhost.conf
@@ -1,0 +1,33 @@
+NameVirtualHost *:80
+
+<VirtualHost _default_:80>
+        ServerAdmin slate@slate.com
+        DocumentRoot /dev/null
+
+        <Proxy *>
+                AddDefaultCharset off
+                Order deny,allow
+                Allow from all
+        </Proxy>
+
+        # Config multi project
+        ProxyRequests Off
+        ProxyPreserveHost On
+
+	<Location />
+                ProxyPass http://0.0.0.0:4567/
+                ProxyPassReverse http://0.0.0.0:4567/
+                Allow from all
+        </Location>
+
+         <Location /__middleman>
+                ProxyPass  http://0.0.0.0:4567/__middleman/
+                ProxyPassReverse  http://0.0.0.0:4567/__middleman/
+                Allow from 91.217.88.144
+                Deny from all
+        </Location>
+
+        LogLevel warn
+        CustomLog /var/log/httpd/access.log combined
+        ErrorLog /var/log/httpd/error.log
+</VirtualHost>

--- a/slate_apache_virtualhost.conf
+++ b/slate_apache_virtualhost.conf
@@ -23,7 +23,7 @@ NameVirtualHost *:80
          <Location /__middleman>
                 ProxyPass  http://0.0.0.0:4567/__middleman/
                 ProxyPassReverse  http://0.0.0.0:4567/__middleman/
-                Allow from 91.217.88.144
+                # Allow from YOUR IP HERE
                 Deny from all
         </Location>
 

--- a/slate_linux_service
+++ b/slate_linux_service
@@ -1,0 +1,47 @@
+#!/bin/bash
+#
+# chkconfig: 35 90 12
+# description: SLATE server
+#
+# Get function from functions library
+. /etc/init.d/functions
+# Start the service slate
+start() {
+        echo -n "Starting slate server:".
+        echo  ""
+	cd /var/www/slate # Change that to your slate installation folder.
+	/usr/local/bin/middleman server &
+        ### Create the lock file ###
+        sudo touch /var/lock/subsys/middleman
+        success $"Slate server startup"
+        echo
+}
+# Restart the service slate
+stop() {
+        echo -n "Stopping slate server: "
+        sudo killall middleman
+        ### Now, delete the lock file ###
+        sudo rm -f /var/lock/subsys/middleman
+        echo
+}
+### main logic ###
+case "$1" in
+  start)
+        start
+        ;;
+  stop)
+        stop
+        ;;
+  status)
+        status middleman
+        ;;
+  restart|reload|condrestart)
+        stop
+        start
+        ;;
+  *)
+        echo $"Slate usage: $0 {start|stop|restart|reload|status}"
+        exit 1
+esac
+exit 0
+


### PR DESCRIPTION
Slate is becoming standard for hosting documentation. It's very robust, configurable and reliable even for big projects. What is missing with it is just simple way of installing that tool - especially on cloud. 

My target is to do some standard packaging for slate for AWS. For now pushing standard slate service - very useful if you want to host slate on linux and apache virtualhost configuration. There is nothing special to do it but I think that this will save lots of time for slate users on linux. I'm open for suggestions and changes. 