### PR TITLE
search.js: Escape the string passed to the jquery selector.

### DIFF
--- a/source/javascripts/app/search.js
+++ b/source/javascripts/app/search.js
@@ -49,7 +49,8 @@
       if (results.length) {
         searchResults.empty();
         $.each(results, function (index, result) {
-          searchResults.append("<li><a href='#" + result.ref + "'>" + $('#'+result.ref).text() + "</a></li>");
+	  var escaped_ref = result.ref.replace(/[!"#$%&'()*+,.\/:;<=>?@[\\\]^`{|}~]/g, "\\$&");
+          searchResults.append("<li><a href='#" + result.ref + "'>" + $('#'+escaped_ref).text() + "</a></li>");
         });
         highlight.call(this);
       } else {


### PR DESCRIPTION
Fixes referencing ids containing special characters.