### PR TITLE
Don't use a selector to get the heading text for search results.

### DIFF
--- a/source/javascripts/app/search.js
+++ b/source/javascripts/app/search.js
@@ -50,7 +50,8 @@
       if (results.length) {
         searchResults.empty();
         $.each(results, function (index, result) {
-          searchResults.append("<li><a href='#" + result.ref + "'>" + $('#'+result.ref).text() + "</a></li>");
+          var elem = document.getElementById(result.ref);
+          searchResults.append("<li><a href='#" + result.ref + "'>" + $(elem).text() + "</a></li>");
         });
         highlight.call(this);
       } else {


### PR DESCRIPTION
Prevents bugs with special CSS characters.

I think this is a more elegant solution for #201, this way we neither need a polyfill nor a regex.