### PR TITLE
Liveish editing with docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.gem
 *.rbc
 .bundle
+vendor/
 .config
 coverage
 InstalledFiles

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,7 @@
 FROM ubuntu:trusty
-
-
 RUN apt-get update
 RUN apt-get install -yq ruby ruby-dev build-essential
 RUN gem install --no-ri --no-rdoc bundler
-
 RUN mkdir /app
 RUN mkdir /app/vendor
 RUN mkdir /app/vendor/bundle
@@ -12,8 +9,6 @@ WORKDIR /app
 ADD ./bundle.config /root/.bundle/config
 ADD ./Gemfile /app/Gemfile
 ADD ./Gemfile.lock /app/Gemfile.lock
-
-
 WORKDIR /app
 EXPOSE 4567
 CMD ["bundle", "exec", "middleman", "server"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,19 @@
 FROM ubuntu:trusty
 
+
 RUN apt-get update
 RUN apt-get install -yq ruby ruby-dev build-essential
 RUN gem install --no-ri --no-rdoc bundler
-ADD Gemfile /app/Gemfile
-ADD Gemfile.lock /app/Gemfile.lock
-RUN cd /app; bundle install
-ADD . /app
-EXPOSE 4567
+
+RUN mkdir /app
+RUN mkdir /app/vendor
+RUN mkdir /app/vendor/bundle
 WORKDIR /app
+ADD ./bundle.config /root/.bundle/config
+ADD ./Gemfile /app/Gemfile
+ADD ./Gemfile.lock /app/Gemfile.lock
+
+
+WORKDIR /app
+EXPOSE 4567
 CMD ["bundle", "exec", "middleman", "server"]

--- a/README.md
+++ b/README.md
@@ -52,8 +52,9 @@ You're going to need:
 Or use the included Dockerfile! (must install Docker first)
 
 ```shell
-docker build -t slate .
-docker run -d -p 4567:4567 slate
+docker-compose build
+docker-compose run slate bundle install
+docker-compose up
 ```
 
 You can now see the docs at <http://localhost:4567>. Whoa! That was fast!

--- a/bundle.config
+++ b/bundle.config
@@ -1,0 +1,3 @@
+BUNDLE_PATH: "vendor/bundle"
+BUNDLE_BIN: "/usr/local/bundle/bin"
+

--- a/bundle.config
+++ b/bundle.config
@@ -1,3 +1,2 @@
 BUNDLE_PATH: "vendor/bundle"
 BUNDLE_BIN: "/usr/local/bundle/bin"
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+files:
+  image: "ubuntu:trusty"
+  volumes:
+    - ./vendor:/app/vendor
+
+slate:
+  build: .
+  command: bundle exec middleman server
+  volumes:
+    - .:/app
+  volumes_from:
+    - files
+  ports:
+    - "4567:4567"
+  links:
+    - files
+


### PR DESCRIPTION
Hi,

This is a simple change to enable live editing (still need to refresh the page with F5) for the docker env.

It cache bundle gem, and share files live with the container using docker-compose.

I change the readme so anyone can try it now and see for themself. it is very easy, follow instruction, then change something in index.md and press F5 on your browser.

Thank you to the tripit team and contribuors of slate!