### PR TITLE
Dockerfile nginx

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,24 @@
-FROM ubuntu:trusty
+FROM ruby:2.2.2
 
-RUN apt-get update
-RUN apt-get install -yq ruby ruby-dev build-essential git
-RUN gem install --no-ri --no-rdoc bundler
-ADD Gemfile /app/Gemfile
-ADD Gemfile.lock /app/Gemfile.lock
-RUN cd /app; bundle install
-ADD . /app
-EXPOSE 4567
-WORKDIR /app
-CMD ["bundle", "exec", "middleman", "server"]
+RUN apt-get update && apt-get install -y nginx
+
+# forward request and error logs to docker log collector
+RUN ln -sf /dev/stdout /var/log/nginx/access.log
+RUN ln -sf /dev/stderr /var/log/nginx/error.log
+
+VOLUME ["/var/cache/nginx"]
+
+EXPOSE 80 443
+CMD ["nginx", "-g", "daemon off;"]
+
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
+ADD Gemfile /usr/src/app/
+ADD Gemfile.lock /usr/src/app/
+RUN bundle install
+
+ADD nginx /etc/nginx
+ADD . /usr/src/app
+
+RUN git init && bundle exec rake build && cp -r build/* /usr/share/nginx/html

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Or use the included Dockerfile! (must install Docker first)
 
 ```shell
 docker build -t slate .
-docker run -d -p 4567:4567 slate
+docker run -d -p 4567:80 slate
 ```
 
 You can now see the docs at <http://localhost:4567>. Whoa! That was fast!

--- a/nginx/conf.d/default.conf
+++ b/nginx/conf.d/default.conf
@@ -1,0 +1,9 @@
+server {
+    listen       80;
+    server_name  localhost;
+
+    location / {
+        root   /usr/share/nginx/html;
+        index  index.html index.htm;
+    }
+}

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,0 +1,28 @@
+#user  nginx;
+worker_processes  1;
+
+error_log  /var/log/nginx/error.log warn;
+pid        /var/run/nginx.pid;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log off;
+
+    sendfile        on;
+    #tcp_nopush     on;
+
+    keepalive_timeout  65;
+    gzip  on;
+
+    include /etc/nginx/conf.d/*.conf;
+}


### PR DESCRIPTION
Changes the dockerfile to compile assets and serve them statically using
nginx. This is faster than using the built-in ruby server and more
in-line with how these might be served in a production environment.

If you are interested in just having this in a `support` or `examples` folder instead of overwriting the main Dockerfile, then I am happy to update the PR. Wanted to at least propose this PR because this is how I have been serving slate docs and have found it to work well since all of the assets are prebuilt.