### PR TITLE
Improved the appearance of code blocks when printing.

### DIFF
--- a/source/stylesheets/print.css.scss
+++ b/source/stylesheets/print.css.scss
@@ -49,6 +49,12 @@ body {
   }
 
   pre {
+    code {
+      border: 0;
+    }
+  }
+
+  pre {
     padding: 1.3em;
   }
 


### PR DESCRIPTION
This is my proposed fix for #308 

With this fix in place, the printed output looks like this:
![screen shot 2015-07-29 at 4 55 04 pm](https://cloud.githubusercontent.com/assets/104575/8969724/3efe5c72-3613-11e5-8d50-e86c41ba0aa9.png)
