### PR TITLE
Remove therubyracer in favor of system JS runtimes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,4 +9,3 @@ gem 'rouge', '~> 1.9.0'
 gem 'redcarpet', '~> 3.3.2'
 
 gem 'rake', '~> 10.4.2'
-gem 'therubyracer', '~> 0.12.1', platforms: :ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,7 +41,6 @@ GEM
     i18n (0.7.0)
     json (1.8.3)
     kramdown (1.7.0)
-    libv8 (3.16.14.7)
     listen (2.10.1)
       celluloid (~> 0.16.0)
       rb-fsevent (>= 0.9.3)
@@ -98,7 +97,6 @@ GEM
     rb-inotify (0.9.5)
       ffi (>= 0.5.0)
     redcarpet (3.3.2)
-    ref (1.0.5)
     rouge (1.9.0)
     sass (3.4.14)
     sprockets (2.12.3)
@@ -111,9 +109,6 @@ GEM
     sprockets-sass (1.3.1)
       sprockets (~> 2.0)
       tilt (~> 1.1)
-    therubyracer (0.12.2)
-      libv8 (~> 3.16.14.0)
-      ref
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (1.4.1)
@@ -137,4 +132,6 @@ DEPENDENCIES
   rake (~> 10.4.2)
   redcarpet (~> 3.3.2)
   rouge (~> 1.9.0)
-  therubyracer (~> 0.12.1)
+
+BUNDLED WITH
+   1.10.5


### PR DESCRIPTION
Resend pull request to base the right branch `dev`.

See also #315.