### PR TITLE
Fix Dockerfile by installing nodejs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:trusty
 
 RUN apt-get update
-RUN apt-get install -yq ruby ruby-dev build-essential git
+RUN apt-get install -yq ruby ruby-dev build-essential git nodejs
 RUN gem install --no-ri --no-rdoc bundler
 ADD Gemfile /app/Gemfile
 ADD Gemfile.lock /app/Gemfile.lock


### PR DESCRIPTION
PR #318 fixes #312 by removing `therubyracer`, but there is no alternative JavaScript runtime in the docker image generated by the Dockerfile, making the server unable to run.

This commit installs Node.js in the Dockerfile to replace `therubyracer` gem.