### PR TITLE
make middleman pick up changes when run in docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Or use the included Dockerfile! (must install Docker first)
 
 ```shell
 docker build -t slate .
-docker run -d -p 4567:4567 slate
+docker run -d -p 4567:4567 --name slate -v $(pwd)/source:/app/source slate
 ```
 
 You can now see the docs at <http://localhost:4567>. Whoa! That was fast!


### PR DESCRIPTION
By mounting a volume middleman can pick up changes to source files while running in the docker container: a simple browser refresh is enough.

This ought to work for most bourne-compatible shells. Fish users simply remove the '$'.

Also, tell docker how to name the container, so we can stop/remove it more easily.