### PR TITLE
upgraded to ubuntu wily to remove error from version trusty

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:trusty
+FROM ubuntu:wily
 
 RUN apt-get update
 RUN apt-get install -yq ruby ruby-dev build-essential git


### PR DESCRIPTION

Running `docker build -t slate .` as stated in the README gave me the error below. I simply went up a version and that fixed it.  


/archive.ubuntu.com/ubuntu/ trusty-security/main libldap-2.4-2 amd64 2.4.31-1+nmu2ubuntu8.1
  404  Not Found [IP: 91.189.91.14 80]
Err http://archive.ubuntu.com/ubuntu/ trusty-security/main linux-libc-dev amd64 3.13.0-61.100
  404  Not Found [IP: 91.189.91.14 80]
Fetched 45.3 MB in 38s (1188 kB/s)
E: Failed to fetch http://archive.ubuntu.com/ubuntu/pool/main/o/openldap/libldap-2.4-2_2.4.31-1+nmu2ubuntu8.1_amd64.deb  404  Not Found [IP: 91.189.91.14 80]

E: Failed to fetch http://archive.ubuntu.com/ubuntu/pool/main/o/openssh/openssh-client_6.6p1-2ubuntu2_amd64.deb  404  Not Found [IP: 91.189.91.14 80]

E: Failed to fetch http://archive.ubuntu.com/ubuntu/pool/main/b/binutils/binutils_2.24-5ubuntu13_amd64.deb  404  Not Found [IP: 91.189.91.14 80]

E: Failed to fetch http://archive.ubuntu.com/ubuntu/pool/main/l/linux/linux-libc-dev_3.13.0-61.100_amd64.deb  404  Not Found [IP: 91.189.91.14 80]

E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
2015/10/11 14:43:35 The command [/bin/sh -c apt-get install -yq ruby ruby-dev build-essential git] returned a non-zero code: 100