### PR TITLE
Use base ruby image in Dockerfile & fix watcher

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,6 @@
-FROM ubuntu:trusty
+FROM ruby:2.2.3-onbuild
 
-RUN apt-get update
-RUN apt-get install -yq ruby ruby-dev build-essential git
-RUN gem install --no-ri --no-rdoc bundler
-ADD Gemfile /app/Gemfile
-ADD Gemfile.lock /app/Gemfile.lock
-RUN cd /app; bundle install
-ADD . /app
+RUN ln -s /usr/src/app /app # Deprecated
+
 EXPOSE 4567
-WORKDIR /app
-CMD ["bundle", "exec", "middleman", "server"]
+CMD ["bundle", "exec", "middleman", "server", "--force-polling"]

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Or use the included Dockerfile! (must install Docker first)
 
 ```shell
 docker build -t slate .
-docker run -d -p 4567:4567 --name slate -v $(pwd)/source:/app/source slate
+docker run -d -p 4567:4567 -v $(pwd)/source:/app/source slate
 ```
 
 You can now see the docs at <http://localhost:4567>. Whoa! That was fast!


### PR DESCRIPTION
It seems that the watcher will not work without the
--force-polling option.