### PR TITLE
toc div fix

### DIFF
--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -350,7 +350,7 @@ html, body {
   }
 
   // the div is the tocify hidden div for placeholding stuff
-  &>h1, &>h2, &>div {
+  &>h1, &>h2, &>div#toc {
     clear:both;
   }
 


### PR DESCRIPTION
sometimes we want to use custom divs in left column, but current css settings dont allow that, becuase content will shift till the end of nearest content in right column. So if this line is only needed for one div, let it be specific by adding an id