### PR TITLE
make tables always full width - expand last column

### DIFF
--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -423,6 +423,10 @@ html, body {
     td {
       padding: 10px;
     }
+    
+    tr td:last-of-type {
+      width: 100%;
+    }
 
     tr:last-child {
       border-bottom: 1px solid #ccc;


### PR DESCRIPTION
this is how it looked before:

<img style="width:100%" alt="screen shot 2016-02-04 at 20 48 15" src="https://cloud.githubusercontent.com/assets/385731/12827957/6d9eb068-cb82-11e5-8a40-c30eba8be320.png">


after it will expand the last column to the full size

<img style="width:100%" alt="screen shot 2016-02-04 at 21 00 42" src="https://cloud.githubusercontent.com/assets/385731/12827958/6da0ea4a-cb82-11e5-89de-b3590a9fe258.png">

