### PR TITLE
Minor English Tweak

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ You can view more in [the list on the wiki](https://github.com/tripit/slate/wiki
 Need Help? Found a bug?
 --------------------
 
-Read our [contribution guidelines](https://github.com/tripit/slate/blob/master/CONTRIBUTING.md), and then [submit a issue](https://github.com/tripit/slate/issues) to the Slate Github if you need any help. And, of course, feel free to submit pull requests with bug fixes or changes.
+Read our [contribution guidelines](https://github.com/tripit/slate/blob/master/CONTRIBUTING.md), and then [submit an issue](https://github.com/tripit/slate/issues) to the Slate Github if you need any help. And, of course, feel free to submit pull requests with bug fixes or changes.
 
 Contributors
 --------------------


### PR DESCRIPTION
Replace `a` with `an`