### PR TITLE
Add Docker support via docker compose

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.git
+source

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM ruby:2.3
+MAINTAINER Carlos Feliciano-Barba <carlos.feliciano@cometa.works>
+
+ENV APP_HOME /usr/src/app/source
+
+VOLUME $APP_HOME
+
+RUN apt-get update && \
+    apt-get install -y \
+    nodejs
+
+WORKDIR $APP_HOME
+
+COPY Gemfile $APP_HOME/Gemfile
+COPY Gemfile.lock $APP_HOME/Gemfile.lock
+
+ENV BUNDLE_GEMFILE=$APP_HOME/Gemfile \
+    BUNDLE_JOBS=20
+
+RUN bundle install
+
+CMD ["bundle", "exec", "middleman", "server", "--force-polling"]
+EXPOSE 4567

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+.PHONY: pull up start all
+
+all:
+	@echo "Commands to build app using docker-compose"
+	@echo "Plain commands default to dev environment"
+	@echo "make build"
+	@echo "make up"
+
+build:
+	docker-compose build
+
+up:
+	docker-compose up

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '2'
+
+services:
+  web:
+    build: .
+    ports:
+      - "4567:4567"
+    volumes:
+      - .:/usr/src/app/source


### PR DESCRIPTION
## Changes
- Add dockerignore
- Add Dockerfile that inherits from ruby:2.3
- Add Makefile for easy building and running(make build, make up)
- Add docker-compose file with v2 syntax for running the server. Needs Docker Compose version to be 1.6 or later

## Running locally
In order to run locally using docker you will just need to do `make build` then `make up`.
This will run the server on port `4567` on your docker machine.