### PR TITLE
Ignore more files in docker images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,12 @@
-build/
+.git/
 .github/
+build/
+.editorconfig
+.gitattributes
+.gitignore
+CHANGELOG.md
+CODE_OF_CONDUCT.md
+deploy.sh
+font-selection.json
+README.md
+Vagrantfile


### PR DESCRIPTION
There are a number of files in the published docker images that do not need to be there to run the image. This PR removes them to save some (very small) amount of size in the resulting image.