### PR TITLE
Change viewport meta tag to allow zooming

### DIFF
--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -28,7 +28,7 @@ under the License.
   <head>
     <meta charset="utf-8">
     <meta content="IE=edge,chrome=1" http-equiv="X-UA-Compatible">
-    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <% if current_page.data.key?('meta') %>
       <% current_page.data.meta.each do |meta| %>
         <meta


### PR DESCRIPTION
Hello! 

I would like to suggest a minor accessibility change to the Slate layout template

Setting `maximum-scale=1` in the HTML viewport tag prevents the user from zooming the page in certain scenarios (e.g. mobile devices). If we remove this from the viewport tag we will allow the user to freely zoom the page.

References that see `maximum-scale=1` as negatively effecting accessibility:

> By setting maximum-scale=1.0, you are disabling the functionality to use pinch zoom on certain mobile devices, forcing people to view your page a certain way.
> The bad way
`<meta
  name="viewport"
  content="width=device-width, initial-scale=1.0, maximum-scale=1.0">`
> The good way
`<meta
  name="viewport"
  content="width=device-width, initial-scale=1.0">`
> Avoiding maximum-scale="1.0" allows your site to meet users' needs and provide a better experience.

https://www.a11yproject.com/posts/never-use-maximum-scale/

> Ensure an accessible viewport
> In addition to setting an initial-scale, you can also set the following attributes on the viewport:
> minimum-scale
> maximum-scale
> user-scalable
> When set, these can disable the user's ability to zoom the viewport, potentially causing accessibility issues. Therefore we would not recommend using these attributes.

https://web.dev/responsive-web-design-basics/#accessible-viewport
