### PR TITLE
Handle incorrectly set language parameter

### DIFF
--- a/source/javascripts/app/_lang.js
+++ b/source/javascripts/app/_lang.js
@@ -143,7 +143,7 @@ under the License.
     languages = l;
 
     var presetLanguage = getLanguageFromQueryString();
-    if (presetLanguage  && (jQuery.inArray(presetLanguage, languages) != -1)) {
+    if (presetLanguage  && languages.includes(presetLanguage)) {
       // the language is in the URL, so use that language!
       activateLanguage(presetLanguage);
 

--- a/source/javascripts/app/_lang.js
+++ b/source/javascripts/app/_lang.js
@@ -143,7 +143,7 @@ under the License.
     languages = l;
 
     var presetLanguage = getLanguageFromQueryString();
-    if (presetLanguage) {
+    if (presetLanguage  && (jQuery.inArray(presetLanguage, languages) != -1)) {
       // the language is in the URL, so use that language!
       activateLanguage(presetLanguage);
 


### PR DESCRIPTION
If the query parameter was set to a language not actually present in the document, no language was selected.