### PR TITLE
Update dockerfile to use ruby 3.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.6-slim
+FROM ruby:3.0-slim
 
 WORKDIR /srv/slate
 


### PR DESCRIPTION
While using the provided Dockerfile an error is generated:

```
44.04 ERROR:  Error installing bundler:
44.04 	The last version of bundler (>= 0) to support your Ruby & RubyGems was 2.4.22. Try installing it with `gem install bundler -v 2.4.22`
44.04 	bundler requires Ruby version >= 3.0.0. The current ruby version is 2.6.10.210.
```

Honouring the suggestion the Docker image is now based on ruby:3.0-slim
