### PR TITLE
update ruby base image on dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.6-slim
+FROM ruby:3-slim
 
 WORKDIR /srv/slate
 


### PR DESCRIPTION
Following this issue #1819, ie, the docker image building fails due to an outdated ruby image version used.

